### PR TITLE
Fix cull particles link in Performance 1.16

### DIFF
--- a/Performance/Performance116.md
+++ b/Performance/Performance116.md
@@ -80,7 +80,7 @@ Mods marked as "*Dangerous*" might be unstable, and cause some unexpected behavi
 | [Spawner Bug Fix](https://www.curseforge.com/minecraft/mc-mods/spawner-fix) | Unknown | This addresses a bug which causes lag in mods that create custom spawners. | Lupicus | Client |
 | [Starlight](https://github.com/PaperMC/Starlight/releases) | Create | Mod for completely rewriting the vanilla light engine. | Spottedleaf (PaperMC) | Both |
 | [Starlight x Create](https://www.curseforge.com/minecraft/mc-mods/starlight-x-create) | Unknown | Mod for completely rewriting the vanilla light engine. | Spottedleaf(PaperMC), Create Patch by: AeiouEnigma, Curseforge Upload and 1.16 Maintained by SirOMGitsYOU | Both |
-| [~~⠀⠀Cull Particles⠀⠀~~](https://www.curseforge.com/minecraft/mc-mods/cull-particles)[²](https://github.com/NordicGamerFE/usefulmods/tree/main#-cull-particles-isnt-needed-anymore-in-newer-forge-versions-it-was-implemented-in-forge)| None | This mod increases fps by not rendering particles that the player can't see | tfarecnim | Client |
+| [~~⠀⠀Cull Particles⠀⠀~~](https://www.curseforge.com/minecraft/mc-mods/cull-particles)[²](https://github.com/NordicGamerFE/usefulmods/tree/main#-cull-particles-isnt-needed-anymore-in-newer-forge-versions-as-it-was-implemented-in-forge)| None | This mod increases fps by not rendering particles that the player can't see | tfarecnim | Client |
 
 
 [![Home](https://i.imgur.com/zGuelkW.png)](https://github.com/NordicGamerFE/usefulmods/blob/main/README.md)

--- a/Performance/Performance116.md
+++ b/Performance/Performance116.md
@@ -80,7 +80,7 @@ Mods marked as "*Dangerous*" might be unstable, and cause some unexpected behavi
 | [Spawner Bug Fix](https://www.curseforge.com/minecraft/mc-mods/spawner-fix) | Unknown | This addresses a bug which causes lag in mods that create custom spawners. | Lupicus | Client |
 | [Starlight](https://github.com/PaperMC/Starlight/releases) | Create | Mod for completely rewriting the vanilla light engine. | Spottedleaf (PaperMC) | Both |
 | [Starlight x Create](https://www.curseforge.com/minecraft/mc-mods/starlight-x-create) | Unknown | Mod for completely rewriting the vanilla light engine. | Spottedleaf(PaperMC), Create Patch by: AeiouEnigma, Curseforge Upload and 1.16 Maintained by SirOMGitsYOU | Both |
-| [~~⠀⠀Cull Particles⠀⠀~~](https://www.toptal.com/developers/hastebin/ativisulut.sql)[²](https://github.com/NordicGamerFE/usefulmods/tree/main#-cull-particles-isnt-needed-anymore-in-newer-forge-versions-it-was-implemented-in-forge)| None | This mod increases fps by not rendering particles that the player can't see | tfarecnim | Client |
+| [~~⠀⠀Cull Particles⠀⠀~~](https://www.curseforge.com/minecraft/mc-mods/cull-particles)[²](https://github.com/NordicGamerFE/usefulmods/tree/main#-cull-particles-isnt-needed-anymore-in-newer-forge-versions-it-was-implemented-in-forge)| None | This mod increases fps by not rendering particles that the player can't see | tfarecnim | Client |
 
 
 [![Home](https://i.imgur.com/zGuelkW.png)](https://github.com/NordicGamerFE/usefulmods/blob/main/README.md)


### PR DESCRIPTION
Why is there a non-existent hastebin link?