### PR TITLE
Mohist 1.19 update

### DIFF
--- a/Software/SoftwareBukkitSpigotETC.md
+++ b/Software/SoftwareBukkitSpigotETC.md
@@ -18,7 +18,7 @@ Join our [discord](https://discord.gg/8nzHYhVUQS) or use the issues.
 | [Glowstone](https://github.com/GlowstoneMC/Glowstone) | Vanilla | 1.12 | Glowstone is a lightweight, from scratch, open source Minecraft server written in Java that supports plugins written for the Bukkit API and its major forks, Spigot and Paper. |
 | [Magma](https://magmafoundation.org) | Forge | 1.12.2, 1.16.5 & 1.18.2 | Minecraft Forge Server Software Implementing Paper/Spigot/Bukkit API. |
 | [MinecraftMist](https://github.com/MinecraftMist/Mist) | Forge | 1.16.5 | Hybrid server software for Minecraft, allowing Forge mods and Bukkit plugins to run together. Rogue fork of Mohist. |
-| [MohistMC](https://mohistmc.com) | Forge | 1.7.10, 1.12.2 & 1.16.5 | Minecraft Forge Server Software Implementing Paper/Spigot/Bukkit API. |
+| [MohistMC](https://mohistmc.com) | Forge | 1.7.10, 1.12.2, 1.16.5 & 1.19 | Minecraft Forge Server Software Implementing Paper/Spigot/Bukkit API. |
 | [Paper](https://papermc.io) | Vanilla | 1.8 - 1.19 | Minecraft server software that was based on the spigot api with their own changes. - High performance Spigot fork that aims to fix gameplay and mechanics inconsistencies |
 | [Pufferfish](https://github.com/pufferfish-gg/Pufferfish) | Vanilla | 1.17 - 1.19 | Software based on paper with their own changes. - A highly optimized Paper fork designed for large servers requiring both maximum performance, stability, and "enterprise" features. |
 | [Purpur](https://purpurmc.org/) | Vanilla | 1.16 - 1.19 | Software based on paper with their own chnages and pufferfish's changes. - Purpur is a drop-in replacement for Paper servers designed for configurability, and new fun and exciting gameplay features. |


### PR DESCRIPTION
Mohist is now working on 1.19.

There also is a 1.18 version, but it will be discontinued soon in favour of 1.19.