### PR TITLE
Update performance 1.18 Rubidium rendering issues with some mods

### DIFF
--- a/Performance/Performance118.md
+++ b/Performance/Performance118.md
@@ -77,7 +77,7 @@ Join our [discord](https://discord.gg/8nzHYhVUQS) or use the issues.
 | [Magnesium](https://www.curseforge.com/minecraft/mc-mods/sodium-reforged) | Optifine, Halogen | (Formerly Sodium Reforged) Unofficial port of "Sodium" to Forge. | someoneelsewastaken | Client | Alpha (3) |
 | [Observable](https://modrinth.com/mod/observable) | Unknown | Shows what's lagging your world/server by profiling (tile) entities. | tasgon | Server | none |
 | [Radium Reforged](https://www.curseforge.com/minecraft/mc-mods/radium-reforged) | Unknown | Radium is an Unofficial Fork of CaffeineMC's "Lithium," made to work with Forge Mod Loader | Asek3 | Both | none |
-| [Rubidium](https://www.curseforge.com/minecraft/mc-mods/rubidium) | Magnesium, Optifine | Rubidium is an Unofficial Fork of CaffeineMC's "Sodium", made to work with Forge Mod Loader | Asek3 | Client | none |
+| [Rubidium](https://www.curseforge.com/minecraft/mc-mods/rubidium) | Magnesium, Optifine, Immersive Engineering Cables does not render, Ars Nouveau Source does not render inside Source Jars | Rubidium is an Unofficial Fork of CaffeineMC's "Sodium", made to work with Forge Mod Loader | Asek3 | Client | none |
 | [Starlight](https://www.curseforge.com/minecraft/mc-mods/starlight-forge) | Unknown | Forge mod for rewriting the light engine to fix lighting performance and lighting errors | SpottedLeaf (PaperMC) | Server | none |
 
 [![Home](https://i.imgur.com/zGuelkW.png)](/README.md)


### PR DESCRIPTION
Immersive Engineering Cables does not render, Ars Nouveau Source does not render inside Source Jars with Rubidium installed i guess it's the same for Magnesium but i didn't tried.

Hopefully this will help some people